### PR TITLE
Upgrade to Mesos 0.28.1 from 0.23.0

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,4 @@
-default['et_mesos']['version']          = "0.23.0-1.0.#{node['platform']}#{node['platform_version'].sub '.', ''}"
+default['et_mesos']['version']          = "0.28.1-2.0.20.#{node['platform']}#{node['platform_version'].sub '.', ''}"
 default['et_mesos']['ssh_opts']         = '-o StrictHostKeyChecking=no ' \
                                           '-o ConnectTimeout=2'
 default['et_mesos']['deploy_with_sudo'] = '1'

--- a/spec/recipes/package_spec.rb
+++ b/spec/recipes/package_spec.rb
@@ -20,7 +20,7 @@ describe 'et_mesos::package' do
 
     it 'installs the default version of the mesos yum package' do
       expect(chef_run).to install_package('mesos').with_version(
-        '0.23.0-1.0.centos66'
+        '0.28.1-2.0.20.centos66'
       )
     end
   end
@@ -64,7 +64,7 @@ describe 'et_mesos::package' do
 
     it 'installs the default version of the mesos package' do
       expect(chef_run).to install_package('mesos').with(
-        version: '0.23.0-1.0.ubuntu1404'
+        version: '0.28.1-2.0.20.ubuntu1404'
       )
     end
   end


### PR DESCRIPTION
Introduces lots of good stuff & fixes:

https://github.com/apache/mesos/blob/0.28.1/CHANGELOG

We’ll want to rebuild the Mesos clusters with this change. Should just be able to spin up all new masters & agents, and decommission the old ones.
