### PR TITLE
Use default level for Java version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,4 +23,4 @@ default['et_mesos']['slave']['cgroups_hierarchy'] = value_for_platform(
   'default' => nil
 )
 
-set['java']['jdk_version'] = '7'
+default['java']['jdk_version'] = '7'


### PR DESCRIPTION
Avoids attribute precedence nastiness, and lets operators sensibly override this value

@eherot, this is gonna bite us, as `et_singularity` v10.0.1 dropped an attribute, and this cookbook‘s `normal` level attribute was now overriding the `default` level set in the `singularity` cookbook.

Gonna ship this ASAP because our Mesos boxes should all be Java 8
